### PR TITLE
Feature/send analytics refactored

### DIFF
--- a/dist/src/UpgradeClient.d.ts
+++ b/dist/src/UpgradeClient.d.ts
@@ -20,8 +20,7 @@ export default class UpgradeClient {
     failedExperimentPoint(experimentPoint: string, reason: string, experimentId?: string): Promise<Interfaces.IFailedExperimentPoint>;
     getAllFeatureFlags(): Promise<IFeatureFlag[]>;
     getFeatureFlag(key: string): IFeatureFlag;
-    log(value: ILogInput[]): Promise<Interfaces.ILog[]>;
-    sendAnalytics(value: ILogInput[]): void;
+    log(value: ILogInput[], sendAnalytics?: boolean): Promise<Interfaces.ILog[]>;
     setAltUserIds(altUserIds: string[]): Promise<Interfaces.IExperimentUserAliases[]>;
     addMetrics(metrics: Array<ISingleMetric | IGroupMetric>): Promise<Interfaces.IMetric[]>;
 }

--- a/dist/src/UpgradeClient.d.ts
+++ b/dist/src/UpgradeClient.d.ts
@@ -20,7 +20,7 @@ export default class UpgradeClient {
     failedExperimentPoint(experimentPoint: string, reason: string, experimentId?: string): Promise<Interfaces.IFailedExperimentPoint>;
     getAllFeatureFlags(): Promise<IFeatureFlag[]>;
     getFeatureFlag(key: string): IFeatureFlag;
-    log(value: ILogInput[], sendAnalytics?: boolean): Promise<Interfaces.ILog[]>;
+    log(value: ILogInput[], sendAsAnalytics?: boolean): Promise<Interfaces.ILog[]>;
     setAltUserIds(altUserIds: string[]): Promise<Interfaces.IExperimentUserAliases[]>;
     addMetrics(metrics: Array<ISingleMetric | IGroupMetric>): Promise<Interfaces.IMetric[]>;
 }

--- a/dist/src/UpgradeClient.d.ts
+++ b/dist/src/UpgradeClient.d.ts
@@ -21,6 +21,7 @@ export default class UpgradeClient {
     getAllFeatureFlags(): Promise<IFeatureFlag[]>;
     getFeatureFlag(key: string): IFeatureFlag;
     log(value: ILogInput[]): Promise<Interfaces.ILog[]>;
+    sendAnalytics(value: ILogInput[]): void;
     setAltUserIds(altUserIds: string[]): Promise<Interfaces.IExperimentUserAliases[]>;
     addMetrics(metrics: Array<ISingleMetric | IGroupMetric>): Promise<Interfaces.IMetric[]>;
 }

--- a/dist/src/common/fetchDataService.d.ts
+++ b/dist/src/common/fetchDataService.d.ts
@@ -1,2 +1,2 @@
 import { Interfaces, Types } from '../identifiers';
-export default function fetchDataService(url: string, token: string, data: any, requestType: Types.REQUEST_TYPES): Promise<Interfaces.IResponse>;
+export default function fetchDataService(url: string, token: string, data: any, requestType: Types.REQUEST_TYPES, sendAsAnalytics?: boolean): Promise<Interfaces.IResponse>;

--- a/dist/src/functions/log.d.ts
+++ b/dist/src/functions/log.d.ts
@@ -1,3 +1,3 @@
 import { Interfaces } from '../identifiers';
 import { ILogInput } from 'upgrade_types';
-export default function log(url: string, userId: string, token: string, value: ILogInput[], sendAnalytics?: boolean): Promise<Interfaces.ILog[]>;
+export default function log(url: string, userId: string, token: string, value: ILogInput[], sendAsAnalytics?: boolean): Promise<Interfaces.ILog[]>;

--- a/dist/src/functions/log.d.ts
+++ b/dist/src/functions/log.d.ts
@@ -1,11 +1,3 @@
 import { Interfaces } from '../identifiers';
 import { ILogInput } from 'upgrade_types';
-export default function log(url: string, userId: string, token: string, value: ILogInput[]): Promise<Interfaces.ILog[]>;
-/**
- *
- * @param url URL of the host to send the analytics to
- * @param userId id of the user
- * @param token additional token to add to the header
- * @param value data to be sent to the server
- */
-export declare function sendAnalytics(url: string, userId: string, token: string, value: ILogInput[]): void;
+export default function log(url: string, userId: string, token: string, value: ILogInput[], sendAnalytics?: boolean): Promise<Interfaces.ILog[]>;

--- a/dist/src/functions/log.d.ts
+++ b/dist/src/functions/log.d.ts
@@ -1,3 +1,4 @@
 import { Interfaces } from '../identifiers';
 import { ILogInput } from 'upgrade_types';
 export default function log(url: string, userId: string, token: string, value: ILogInput[]): Promise<Interfaces.ILog[]>;
+export function sendAnalytics(url: string, userId: string, token: string, value: ILogInput[]): void;

--- a/dist/src/functions/log.d.ts
+++ b/dist/src/functions/log.d.ts
@@ -1,4 +1,11 @@
 import { Interfaces } from '../identifiers';
 import { ILogInput } from 'upgrade_types';
 export default function log(url: string, userId: string, token: string, value: ILogInput[]): Promise<Interfaces.ILog[]>;
-export function sendAnalytics(url: string, userId: string, token: string, value: ILogInput[]): void;
+/**
+ *
+ * @param url URL of the host to send the analytics to
+ * @param userId id of the user
+ * @param token additional token to add to the header
+ * @param value data to be sent to the server
+ */
+export declare function sendAnalytics(url: string, userId: string, token: string, value: ILogInput[]): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade_client_lib",
-  "version": "1.0.11",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/UpgradeClient.ts
+++ b/src/UpgradeClient.ts
@@ -115,7 +115,7 @@ export default class UpgradeClient {
         this.validateClient();
         return await failedExperimentPoint(UpgradeClient.api.failedExperimentPoint, this.token, experimentPoint, reason, this.userId, experimentId);
     }
-    
+
     async getAllFeatureFlags(): Promise<IFeatureFlag[]> {
         this.validateClient();
         const response = await getAllFeatureFlags(UpgradeClient.api.getAllFeatureFlag, this.token);
@@ -130,13 +130,9 @@ export default class UpgradeClient {
         return getFeatureFlag(this.featureFlags, key);
     }
 
-    async log(value: ILogInput[]): Promise<Interfaces.ILog[]> {
+    async log(value: ILogInput[], sendAsAnalytics = false): Promise<Interfaces.ILog[]> {
         this.validateClient();
-        return await log(UpgradeClient.api.log, this.userId, this.token, value);
-    }
-
-    sendAnalytics(value: ILogInput[]): void {
-        return sendAnalytics(UpgradeClient.api.log, this.userId, this.token, value);
+        return await log(UpgradeClient.api.log, this.userId, this.token, value, sendAsAnalytics);
     }
 
     async setAltUserIds(altUserIds: string[]): Promise<Interfaces.IExperimentUserAliases[]> {

--- a/src/UpgradeClient.ts
+++ b/src/UpgradeClient.ts
@@ -7,7 +7,7 @@ import getExperimentCondition from './functions/getExperimentCondition';
 import markExperimentPoint from './functions/markExperimentPoint';
 import failedExperimentPoint from './functions/failedExperimentPoint';
 import getAllFeatureFlags from './functions/getAllfeatureFlags';
-import log from './functions/log';
+import log, { sendAnalytics } from './functions/log';
 import setAltUserIds from './functions/setAltUserIds';
 import addMetrics from './functions/addMetrics';
 import getFeatureFlag from './functions/getFeatureFlag';
@@ -133,6 +133,10 @@ export default class UpgradeClient {
     async log(value: ILogInput[]): Promise<Interfaces.ILog[]> {
         this.validateClient();
         return await log(UpgradeClient.api.log, this.userId, this.token, value);
+    }
+
+    sendAnalytics(value: ILogInput[]): void {
+        return sendAnalytics(UpgradeClient.api.log, this.userId, this.token, value);
     }
 
     async setAltUserIds(altUserIds: string[]): Promise<Interfaces.IExperimentUserAliases[]> {

--- a/src/UpgradeClient.ts
+++ b/src/UpgradeClient.ts
@@ -7,7 +7,7 @@ import getExperimentCondition from './functions/getExperimentCondition';
 import markExperimentPoint from './functions/markExperimentPoint';
 import failedExperimentPoint from './functions/failedExperimentPoint';
 import getAllFeatureFlags from './functions/getAllfeatureFlags';
-import log, { sendAnalytics } from './functions/log';
+import log from './functions/log';
 import setAltUserIds from './functions/setAltUserIds';
 import addMetrics from './functions/addMetrics';
 import getFeatureFlag from './functions/getFeatureFlag';

--- a/src/common/fetchDataService.ts
+++ b/src/common/fetchDataService.ts
@@ -2,13 +2,13 @@ import { Interfaces, Types } from '../identifiers';
 import * as fetch from 'isomorphic-fetch';
 
 // Call this function with url and data which is used in body of request
-export default async function fetchDataService(url: string, token: string, data: any, requestType: Types.REQUEST_TYPES): Promise<Interfaces.IResponse> {
+export default async function fetchDataService(url: string, token: string, data: any, requestType: Types.REQUEST_TYPES, sendAsAnalytics = false): Promise<Interfaces.IResponse> {
   const requestCount = 0;
   const requestThreshold = 5;
-  return await fetchDataFromDB(url, token, data, requestType, requestCount, requestThreshold);
+  return await fetchDataFromDB(url, token, data, requestType, requestCount, requestThreshold, sendAsAnalytics);
 }
 
-async function fetchDataFromDB(url: string, token: string, data: any, requestType: Types.REQUEST_TYPES, requestCount: number, requestThreshold: number): Promise<Interfaces.IResponse> {
+async function fetchDataFromDB(url: string, token: string, data: any, requestType: Types.REQUEST_TYPES, requestCount: number, requestThreshold: number, sendAsAnalytics = false): Promise<Interfaces.IResponse> {
   try {
     let options: any = {
       method: requestType,
@@ -31,10 +31,17 @@ async function fetchDataFromDB(url: string, token: string, data: any, requestTyp
         body: JSON.stringify(data)
       }
     }
+
+    if (sendAsAnalytics === true) {
+      options = {
+        ...options,
+        keepalive: true
+      }
+    }
     const response = await fetch(url, options);
     const responseData = await response.json();
     // If name, endpoint and message appears in response then its error
-    const status =  !responseData.name && !responseData.endPoint && !responseData.message;
+    const status = !responseData.name && !responseData.endPoint && !responseData.message;
     return {
       status,
       data: responseData

--- a/src/common/fetchDataService.ts
+++ b/src/common/fetchDataService.ts
@@ -11,13 +11,17 @@ export default async function fetchDataService(url: string, token: string, data:
 async function fetchDataFromDB(url: string, token: string, data: any, requestType: Types.REQUEST_TYPES, requestCount: number, requestThreshold: number, sendAsAnalytics = false): Promise<Interfaces.IResponse> {
   try {
 
-    const headers = new Headers();
-    headers.append('Content-Type', 'application/json');
+    let headers: any = {
+      'Content-Type': 'application/json'
+    }
     if (!!token) {
-      headers.append('Authorization', `Bearer ${token}`);
+      headers = {
+        ...headers,
+        'Authorization': `Bearer ${token}`
+      }
     }
 
-    
+
     let options: any = {
       headers,
       method: requestType,
@@ -30,7 +34,7 @@ async function fetchDataFromDB(url: string, token: string, data: any, requestTyp
         body: JSON.stringify(data)
       }
     }
-    
+
     const response = await fetch(url, options);
     const responseData = await response.json();
     // If name, endpoint and message appears in response then its error

--- a/src/common/fetchDataService.ts
+++ b/src/common/fetchDataService.ts
@@ -10,34 +10,27 @@ export default async function fetchDataService(url: string, token: string, data:
 
 async function fetchDataFromDB(url: string, token: string, data: any, requestType: Types.REQUEST_TYPES, requestCount: number, requestThreshold: number, sendAsAnalytics = false): Promise<Interfaces.IResponse> {
   try {
-    let options: any = {
-      method: requestType,
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    };
-    if (token) {
-      options = {
-        ...options,
-        headers: {
-          ...options.headers,
-          'Authorization': `Bearer ${token}`
-        }
-      }
+
+    const headers = new Headers();
+    headers.append('Content-Type', 'application/json');
+    if (!!token) {
+      headers.append('Authorization', `Bearer ${token}`);
     }
+
+    
+    let options: any = {
+      headers,
+      method: requestType,
+      keepalive: sendAsAnalytics === true
+    };
+
     if (requestType === Types.REQUEST_TYPES.POST) {
       options = {
         ...options,
         body: JSON.stringify(data)
       }
     }
-
-    if (sendAsAnalytics === true) {
-      options = {
-        ...options,
-        keepalive: true
-      }
-    }
+    
     const response = await fetch(url, options);
     const responseData = await response.json();
     // If name, endpoint and message appears in response then its error

--- a/src/functions/log.ts
+++ b/src/functions/log.ts
@@ -1,6 +1,7 @@
 import { Types, Interfaces } from '../identifiers';
 import fetchDataService from '../common/fetchDataService';
 import { ILogInput } from 'upgrade_types';
+import * as fetch from 'isomorphic-fetch';
 
 export default async function log(
   url: string,
@@ -37,30 +38,28 @@ export function sendAnalytics(
   token: string,
   value: ILogInput[]
 ): void {
+
   const data = {
     userId,
     value
   };
 
   let headers: any = {
-    'Content-Type': 'application/json'
-  }
+    'Content-Type': 'application/json',
+  };
 
   if (!!token) {
     headers = {
       ...headers,
       'Authorization': `Bearer ${token}`
-    }
+    };
   }
+  const body = JSON.stringify(data);
 
-  const blob = new Blob([JSON.stringify(data)], headers);
-  if (navigator.sendBeacon) {
-    navigator.sendBeacon(url, blob);
-  } else {
-    console.error('navigator.sendBeacon not supported');
-    // handle with xhr fallback
-    const xhr = new XMLHttpRequest();
-    xhr.open('post', url, false);
-    xhr.send(blob);
-  }
+  fetch(url, {
+    method: 'POST',
+    keepalive: true,
+    body,
+    headers
+  });
 }

--- a/src/functions/log.ts
+++ b/src/functions/log.ts
@@ -1,20 +1,20 @@
 import { Types, Interfaces } from '../identifiers';
 import fetchDataService from '../common/fetchDataService';
 import { ILogInput } from 'upgrade_types';
-import * as fetch from 'isomorphic-fetch';
 
 export default async function log(
   url: string,
   userId: string,
   token: string,
-  value: ILogInput[]
+  value: ILogInput[],
+  sendAsAnalytics = false
 ): Promise<Interfaces.ILog[]> {
   try {
     const data = {
       userId,
       value
     };
-    const logResponse = await fetchDataService(url, token, data, Types.REQUEST_TYPES.POST);
+    const logResponse = await fetchDataService(url, token, data, Types.REQUEST_TYPES.POST, sendAsAnalytics);
     if (logResponse.status) {
       return logResponse.data;
     } else {
@@ -23,43 +23,4 @@ export default async function log(
   } catch (error) {
     throw new Error(error);
   }
-}
-
-/**
- * 
- * @param url URL of the host to send the analytics to
- * @param userId id of the user
- * @param token additional token to add to the header
- * @param value data to be sent to the server
- */
-export function sendAnalytics(
-  url: string,
-  userId: string,
-  token: string,
-  value: ILogInput[]
-): void {
-
-  const data = {
-    userId,
-    value
-  };
-
-  let headers: any = {
-    'Content-Type': 'application/json',
-  };
-
-  if (!!token) {
-    headers = {
-      ...headers,
-      'Authorization': `Bearer ${token}`
-    };
-  }
-  const body = JSON.stringify(data);
-
-  fetch(url, {
-    method: Types.REQUEST_TYPES.POST,
-    keepalive: true,
-    body,
-    headers
-  });
 }

--- a/src/functions/log.ts
+++ b/src/functions/log.ts
@@ -57,7 +57,7 @@ export function sendAnalytics(
   const body = JSON.stringify(data);
 
   fetch(url, {
-    method: 'POST',
+    method: Types.REQUEST_TYPES.POST,
     keepalive: true,
     body,
     headers

--- a/src/functions/log.ts
+++ b/src/functions/log.ts
@@ -24,6 +24,13 @@ export default async function log(
   }
 }
 
+/**
+ * 
+ * @param url URL of the host to send the analytics to
+ * @param userId id of the user
+ * @param token additional token to add to the header
+ * @param value data to be sent to the server
+ */
 export function sendAnalytics(
   url: string,
   userId: string,

--- a/src/functions/log.ts
+++ b/src/functions/log.ts
@@ -23,3 +23,37 @@ export default async function log(
     throw new Error(error);
   }
 }
+
+export function sendAnalytics(
+  url: string,
+  userId: string,
+  token: string,
+  value: ILogInput[]
+): void {
+  const data = {
+    userId,
+    value
+  };
+
+  let headers: any = {
+    'Content-Type': 'application/json'
+  }
+
+  if (!!token) {
+    headers = {
+      ...headers,
+      'Authorization': `Bearer ${token}`
+    }
+  }
+
+  const blob = new Blob([JSON.stringify(data)], headers);
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(url, blob);
+  } else {
+    console.error('navigator.sendBeacon not supported');
+    // handle with xhr fallback
+    const xhr = new XMLHttpRequest();
+    xhr.open('post', url, false);
+    xhr.send(blob);
+  }
+}


### PR DESCRIPTION
This is just a refactored version of the previous PR. I feel this code is more appropriate.

adding flag : sendAsAnalytics for sending analytics data when the user navigates away to another page using fetch with 'keepalive' flag true

Reason for the addition:
sending the data without 'keepalive' flagged fetch is not possible as the browser tends to ignore the async call generated and cancels it. Setting the flag will tell the browser not to wait for the response but to send the request anyway.

Reason for conditionally setting the 'keepalive' flag:
'keepalive' comes with limitations as mentioned here: https://javascript.info/fetch-api#keepalive.
> It does not allow any ACTIVE request to be over 64kb.
> Server response cannot be handled as the browser is already unloaded in the mean time.