### PR TITLE
Java client lib: Require callers of getExperimentCondition() to provide a context

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.upgradeplatform</groupId>
 	<artifactId>upgrade-client</artifactId>
-	<version>0.2.1</version>
+	<version>0.3</version>
 
 	<build>
 		<plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.upgradeplatform</groupId>
 	<artifactId>upgrade-client</artifactId>
-	<version>0.2</version>
+	<version>0.2.1</version>
 
 	<build>
 		<plugins>

--- a/java/src/main/java/org/upgradeplatform/client/ExperimentClient.java
+++ b/java/src/main/java/org/upgradeplatform/client/ExperimentClient.java
@@ -147,13 +147,13 @@ public class ExperimentClient implements AutoCloseable {
 	}
 
     /**@param experimentPoint This is matched case-insensitively*/
-	public void getExperimentCondition(String experimentPoint, final ResponseCallback<ExperimentsResponse> callbacks) {
-		getExperimentCondition(experimentPoint, null, callbacks);
+	public void getExperimentCondition(String context, String experimentPoint, final ResponseCallback<ExperimentsResponse> callbacks) {
+		getExperimentCondition(context, experimentPoint, null, callbacks);
 	}
 
     /**@param experimentPoint This is matched case-insensitively
      * @param experimentId This is matched case-insensitively*/
-	public void getExperimentCondition(String experimentPoint, String experimentId,
+	public void getExperimentCondition(String context, String experimentPoint, String experimentId,
 			final ResponseCallback<ExperimentsResponse> callbacks) {
 		if (this.allExperiments != null) {
 
@@ -163,7 +163,7 @@ public class ExperimentClient implements AutoCloseable {
 				callbacks.onSuccess(resultCondition);
 			}
 		} else {
-			getAllExperimentCondition("", new ResponseCallback<List<ExperimentsResponse>>() {
+			getAllExperimentCondition(context, new ResponseCallback<List<ExperimentsResponse>>() {
 				@Override
 				public void onSuccess(@NonNull List<ExperimentsResponse> experiments) {
 

--- a/java/src/main/java/org/upgradeplatform/client/ExperimentClient.java
+++ b/java/src/main/java/org/upgradeplatform/client/ExperimentClient.java
@@ -146,10 +146,13 @@ public class ExperimentClient implements AutoCloseable {
 		}));
 	}
 
+    /**@param experimentPoint This is matched case-insensitively*/
 	public void getExperimentCondition(String experimentPoint, final ResponseCallback<ExperimentsResponse> callbacks) {
 		getExperimentCondition(experimentPoint, null, callbacks);
 	}
 
+    /**@param experimentPoint This is matched case-insensitively
+     * @param experimentId This is matched case-insensitively*/
 	public void getExperimentCondition(String experimentPoint, String experimentId,
 			final ResponseCallback<ExperimentsResponse> callbacks) {
 		if (this.allExperiments != null) {
@@ -184,9 +187,9 @@ public class ExperimentClient implements AutoCloseable {
 	private ExperimentsResponse findExperimentResponse(String experimentPoint, String experimentId,
 			List<ExperimentsResponse> experiments) {
 		return experiments.stream()
-				.filter(t -> t.getExpPoint().equals(experimentPoint) &&
+				.filter(t -> t.getExpPoint().equalsIgnoreCase(experimentPoint) &&
 						(isStringNull(experimentId) ? isStringNull(t.getExpId().toString())
-								: t.getExpId().toString().equals(experimentId)))
+								: t.getExpId().toString().equalsIgnoreCase(experimentId)))
 				.findFirst()
 				.map(ExperimentClient::copyExperimentResponse)
 				.orElse(new ExperimentsResponse());


### PR DESCRIPTION
This is necessary for UpGrade clients that don't call the plural version of this API method to work correctly.

This is built on top of the changes from #58 because otherwise it would have a merge conflict with that commit.